### PR TITLE
#23 Hyperlinks are now more visible + other related fixes

### DIFF
--- a/components/molecules/CompactCard.js
+++ b/components/molecules/CompactCard.js
@@ -37,7 +37,7 @@ export default function CompactCard(props) {
                     </div>
                     <div className={styles.bottomContent}>
                         <h2 className={styles.title}>{props.post.title}</h2>
-                        <p className={styles.description}>{props.post.excerpt.substr(0, 80)}...</p>
+                        <p className={styles.description}>{props.post.excerpt}</p>
                     </div>
                 </div>
             </div>

--- a/components/stylesheets/Card.module.css
+++ b/components/stylesheets/Card.module.css
@@ -10,6 +10,7 @@
     box-shadow: var(--article-shadow-normal), 0 0 0 transparent;
     transition: all 0.25s cubic-bezier(0.02, 0.01, 0.47, 1);
     z-index: 1;
+    cursor: pointer;
 }
 
 .card:first-of-type {
@@ -24,10 +25,6 @@
     transform: translateY(-5px);
     -o-box-shadow: var(--article-shadow-hover), 0 0 0 transparent;
     box-shadow: var(--article-shadow-hover), 0 0 0 transparent;
-}
-
-.image, .title, .description, .timeStamps {
-    cursor: pointer;
 }
 
 .author {
@@ -61,6 +58,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
     padding: 25px;
 }
 
@@ -69,22 +67,22 @@
 }
 
 .tag {
-    color: var(--link-color);
+    color: var(--card-tag-color);
     font-size: 14px;
     font-weight: 600;
     text-decoration: none;
     letter-spacing: 0.2px;
-    line-height: 1.3;
-    -webkit-line-clamp: 1;
-    width: calc(100% - 40px);
-    min-height: 20.2px;
-    max-height: 20.2px;
+    height: 20.2px;
     margin-bottom: 5px;
-    white-space: nowrap;
+    display: -webkit-box;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.tag:hover {
+    text-decoration: underline;
 }
 
 .title {

--- a/components/stylesheets/CompactCard.module.css
+++ b/components/stylesheets/CompactCard.module.css
@@ -11,16 +11,13 @@
     box-shadow: var(--article-shadow-normal), 0 0 0 transparent;
     transition: all 0.25s cubic-bezier(0.02, 0.01, 0.47, 1);
     z-index: 1;
+    cursor: pointer;
 }
 
 .card:hover {
     transform: translateY(-5px);
     -o-box-shadow: var(--article-shadow-hover), 0 0 0 transparent;
     box-shadow: var(--article-shadow-hover), 0 0 0 transparent;
-}
-
-.image, .title, .description, .timeStamps {
-    cursor: pointer;
 }
 
 .image {
@@ -58,14 +55,12 @@
 }
 
 .tag {
-    color: var(--link-color);
+    color: var(--card-tag-color);
     font-size: 14px;
     font-weight: 600;
     text-decoration: none;
     letter-spacing: 0.2px;
     line-height: 1.3;
-    -webkit-line-clamp: 1;
-    width: calc(100% - 40px);
     min-height: 20.2px;
     max-height: 20.2px;
     white-space: nowrap;
@@ -73,6 +68,10 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.tag:hover {
+    text-decoration: underline;
 }
 
 .title {
@@ -85,11 +84,17 @@
 }
 
 .description {
-    /* flex: 2; */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
 }
 
 .timeStamps {
+    flex: 1;
     color: var(--titles-color);
+    text-align: end;
     letter-spacing: 0.2px;
     font-size: 0.875rem;
     white-space: nowrap;

--- a/components/stylesheets/EpisodeList.module.css
+++ b/components/stylesheets/EpisodeList.module.css
@@ -46,3 +46,9 @@
         padding: 70px 20px 20px 20px;
     }
 }
+
+@media only screen and (max-width: 355px) {
+    .episodeList {
+        padding: 70px 0 20px 0;
+    }
+}

--- a/components/stylesheets/Footer.module.css
+++ b/components/stylesheets/Footer.module.css
@@ -18,6 +18,10 @@
     margin: 0;
 }
 
+.footer a:hover {
+    text-decoration: underline;
+}
+
 .row svg path {
     fill: white;
 }

--- a/components/stylesheets/styles.css
+++ b/components/stylesheets/styles.css
@@ -22,6 +22,7 @@
     --button-shadow-color-hover: hsla(0, 0%, 42.4%, 0.3);
     --mdc-theme-primary: #4a4a4a;
     --menu-titles-color: #ffffff;
+    --card-tag-color: #205482;
 
     --busrides-red: #CE3F3F;
     
@@ -52,6 +53,7 @@
         --button-shadow-color-normal: rgba(10, 10, 10, 0.5);
         --button-shadow-color-hover: rgba(10, 10, 10, 0.5);
         --mdc-theme-primary: #e3e3e3;
+        --card-tag-color: #5DAFD6;
     }
 }
 


### PR DESCRIPTION
Hyperlinks now become underlined when hovered over, specifically on cards and in the footer.

Topic links in cards while in light mode have a new colour variable, dark mode remained the same colour.

Fixed an issue where clicking anything in the same row as the topic would take you to the topic rather than the episode.

Introduced a better way of clipping long episode descriptions.

Applied changes to the compact card view as well.